### PR TITLE
Recipe list editor

### DIFF
--- a/Play-assets/store-description.txt
+++ b/Play-assets/store-description.txt
@@ -1,6 +1,10 @@
 • <b>Combined interval timer/stopwatch</b> = periodic alarms + elapsed time.
-  Reminds you periodically to turn the food while it tracks the total cooking time.
-• Quick access via <b>lock screen notification</b> and <b>home screen widget</b>.
+  Reminds you periodically to turn the food and tracks the total
+  cooking time.
+• Quick access via <b>lock screen notification</b>, <b>pull-down notification</b>,
+  and <b>home screen widget</b>.
+• Editable <b>pop-up menu of interval times</b>. Quickly access your favorite
+  timers, each with optional notes.
 • <b>Changeable alarms</b> while it’s running.
 • No ads.
 
@@ -28,6 +32,8 @@ Short forms:
 • While BBQ Timer is <i>running</i> or <i>paused</i>, it appears <b>on the lock screen</b> and <b>in the pull-down notification</b> so you can see and control it in those places.
   • To put it on the lock screen, put it in <b>Pause</b> or <b>Play</b> mode by tapping buttons in the app or the home screen widget.
   • You can long-press the app’s home screen icon, then tap the “Pause at 00:00” shortcut (on Android 7.1+) to make it Paused and ready on the lock screen.
+• Tap ▲ in the alarm interval text field for the pop-up menu of interval times.
+  • Tap “Edit these intervals…” in the menu to customize the menu.
 • The app, home screen widget, and pull-down notification show the countdown interval time as well as the total elapsed time (requires Android 7+).
 • You can change BBQ Timer’s “Alarm” sound in Settings - Notifications. Don’t pick “None” if you want to hear the interval alarms. To restore the app’s cowbell sound, uninstall and reinstall the app.
 

--- a/Play-assets/store-description_de.txt
+++ b/Play-assets/store-description_de.txt
@@ -1,6 +1,10 @@
 • <b>Kombinierter Intervalltimer/Stoppuhr</b> = periodische Alarme + verstrichene Zeit.
-  Erinnert Sie regelmäßig daran, die Speisen zu wenden, während die Gesamtgarzeit verfolgt wird.
-• Schnellzugriff über <b>Sperrbildschirmbenachrichtigung</b> und <b>Startbildschirm-Widget</b>.
+  Erinnert Sie regelmäßig daran, die Speisen zu wenden und verfolgt
+  die gesamte Garzeit.
+• Schneller Zugriff über <b>Sperrbildschirmbenachrichtigung</b>,
+  <b>Pulldown-Benachrichtigung</b> und <b>Startbildschirm-Widget</b>.
+• Bearbeitbares <b>Popup-Menü der Intervallzeiten</b>. Greifen Sie schnell auf
+  Ihre bevorzugten Timer zu, jeweils mit optionalen Notizen.
 • <b>Änderbare Alarme</b> während es läuft.
 • Keine Werbung.
 
@@ -28,6 +32,8 @@ Kurz Formen:
 • Während der BBQ-Timer <i>läuft</i> oder <i>pausiert</i> ist, erscheint er <b>auf dem Sperrbildschirm</b> und <b>in der Pulldown-Benachrichtigung</b> Sie können es an diesen Stellen sehen und steuern.
   • Um es auf den Sperrbildschirm zu setzen, versetzen Sie es in den Modus <b>Pause</b> oder <b>Wiedergabe</b>, indem Sie auf Schaltflächen in der App oder im Startbildschirm-Widget tippen.
   • Sie können lange auf das Startbildschirmsymbol der App drücken und dann auf die Verknüpfung „Anhalten bei 00:00“ (auf Android 7.1+) tippen, um sie auf dem Sperrbildschirm anzuhalten und bereit zu machen.
+• Tippen Sie im Textfeld „Alarmintervall“ auf ▲, um das Popup-Menü für die Intervallzeit aufzurufen.
+  • Tippen Sie im Menü auf „Diese Intervalle bearbeiten…“, um das Menü anzupassen.
 • Die App, das Startbildschirm-Widget und die Pulldown-Benachrichtigung zeigen die Countdown-Intervallzeit sowie die verstrichene Gesamtzeit (erfordert Android 7+).
 • Sie können den „Alarm“-Ton von BBQ Timer in Einstellungen – Benachrichtigungen ändern. Wählen Sie nicht „Keine“, wenn Sie die Intervallalarme hören möchten. Um den Kuhglockenklang der App wiederherzustellen, deinstallieren Sie die App und installieren Sie sie erneut.
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,10 @@
 
 * **Combined interval timer/stopwatch** = periodic alarms + elapsed time.  
   Reminds you periodically to turn the food while it tracks the total cooking time.
-* Quick access via **lock screen notification** and **home screen widget**.
+* Quick access via **lock screen notification**, **pull-down notification**, and
+ **home screen widget**.
+* Editable **pop-up menu of interval times**. Quickly access your favorite timers,
+  each with optional notes.
 * **Changeable alarms** while it’s running.
 * No ads.
 
@@ -43,6 +46,8 @@ version, screen size, problem symptom, Android "bugreport" file).
 * While BBQ Timer is *running* or *paused*, it appears **on the lock screen** and **in the pull-down notification** so you can see and control it in those places.
   * To put it on the lock screen, put it in **Pause** or **Play** mode by tapping buttons in the app or the home screen widget.
   * You can long-press the app’s home screen icon, then tap the “Pause at 00:00” shortcut (on Android 7.1+) to make it Paused and ready on the lock screen.
+* Tap ▲ in the alarm interval text field to open the pop-up menu of interval times.
+  * Tap “Edit these intervals…” in the menu to customize the menu.
 * The app, home screen widget, and pull-down notification show the countdown interval time as well as the total elapsed time (requires Android 7+).
 * You can change BBQ Timer’s “Alarm” sound in Settings - Notifications. Don’t pick “None” if you want to hear the interval alarms. To restore the app’s cowbell sound, uninstall and reinstall the app.
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,7 +9,7 @@ android {
     defaultConfig {
         applicationId "com.onefishtwo.bbqtimer"
         versionCode 22
-        versionName '3.1'
+        versionName '4.0'
         minSdk 22
         targetSdk 30
         resConfigs 'en', 'de'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -43,8 +43,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_1_9
+        targetCompatibility JavaVersion.VERSION_1_9
     }
 
     testOptions {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,7 +10,7 @@ android {
         applicationId "com.onefishtwo.bbqtimer"
         versionCode 22
         versionName '3.1'
-        minSdk 21
+        minSdk 22
         targetSdk 30
         resConfigs 'en', 'de'
 

--- a/app/src/androidTest/java/com/onefishtwo/bbqtimer/CustomMatchers.java
+++ b/app/src/androidTest/java/com/onefishtwo/bbqtimer/CustomMatchers.java
@@ -48,7 +48,7 @@ class CustomMatchers {
     static Matcher<View> childAtPosition(
             @NonNull final Matcher<View> parentMatcher, final int position) {
 
-        return new TypeSafeMatcher<View>() {
+        return new TypeSafeMatcher<>() {
             @Override
             public void describeTo(@NonNull Description description) {
                 description.appendText("Child at position " + position + " in parent ");
@@ -71,7 +71,7 @@ class CustomMatchers {
     @SuppressWarnings("SpellCheckingInspection")
     @NonNull
     static Matcher<View> withCompoundDrawable(@DrawableRes final int resourceId) {
-        return new BoundedMatcher<View, TextView>(TextView.class) {
+        return new BoundedMatcher<>(TextView.class) {
             @Override
             public void describeTo(@NonNull Description description) {
                 description.appendText("has compound drawable resource " + resourceId);

--- a/app/src/androidTest/java/com/onefishtwo/bbqtimer/CustomViewActions.java
+++ b/app/src/androidTest/java/com/onefishtwo/bbqtimer/CustomViewActions.java
@@ -77,7 +77,7 @@ class CustomViewActions {
             @NonNull
             @Override
             public BaseMatcher<View> getConstraints() {
-                return new BaseMatcher<View>() {
+                return new BaseMatcher<>() {
                     @Override
                     public boolean matches(Object item) {
                         return isA(Checkable.class).matches(item);

--- a/app/src/androidTest/java/com/onefishtwo/bbqtimer/InAppUITest.java
+++ b/app/src/androidTest/java/com/onefishtwo/bbqtimer/InAppUITest.java
@@ -60,7 +60,6 @@ import static androidx.test.espresso.matcher.ViewMatchers.isEnabled;
 import static androidx.test.espresso.matcher.ViewMatchers.isNotChecked;
 import static androidx.test.espresso.matcher.ViewMatchers.withContentDescription;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
-import static androidx.test.espresso.matcher.ViewMatchers.withParent;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
 import static com.onefishtwo.bbqtimer.CustomMatchers.withCompoundDrawable;
 import static com.onefishtwo.bbqtimer.CustomViewActions.waitMsec;
@@ -70,6 +69,7 @@ import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertEquals;
 
 /** Within-app Espresso UI tests. */
@@ -420,13 +420,13 @@ public class InAppUITest {
         popupMenuButton.perform(click());
 
         ViewInteraction cmdEdit = checkMenuCommand(R.string.edit_this_list);
+        ViewInteraction cmd_6 = checkMenuCommandPrefix("6 ");
+        ViewInteraction cmd_7 = checkMenuCommandPrefix("7 ");
         ViewInteraction cmd__30 = checkMenuCommand(":30");
         ViewInteraction cmd_1 = checkMenuCommand("1");
-        ViewInteraction cmd_1_30 = checkMenuCommand("1:30");
-        ViewInteraction cmd_5 = checkMenuCommand("5");
+        // NOTE: Commands scrolled off the bottom require scrolling to access.
 
         // Pick the first few intervals from the menu.
-        // NOTE: Commands scrolled off the bottom require scrolling to access.
         cmd__30.perform(click());
         alarmPeriodTextField.check(matches(withText("0:30")));
 
@@ -435,8 +435,12 @@ public class InAppUITest {
         alarmPeriodTextField.check(matches(withText("1")));
 
         popupMenuButton.perform(click());
-        cmd_1_30.perform(click());
-        alarmPeriodTextField.check(matches(withText("1:30")));
+        cmd_6.perform(click());
+        alarmPeriodTextField.check(matches(withText("6")));
+
+        popupMenuButton.perform(click());
+        cmd_7.perform(click());
+        alarmPeriodTextField.check(matches(withText("7")));
 
         // Open the recipe editor dialog, edit the text, then Cancel.
         popupMenuButton.perform(click());
@@ -489,7 +493,8 @@ public class InAppUITest {
         popupMenuButton.perform(click());
         cmd__30.check(matches(isDisplayed()));
         cmd_1.check(matches(isDisplayed()));
-        cmd_1_30.check(matches(isDisplayed()));
+        cmd_6.check(matches(isDisplayed()));
+        cmd_7.check(matches(isDisplayed()));
 
         cmd_1.perform(waitMsec(500), click()); // delay for a visual check
     }
@@ -503,8 +508,7 @@ public class InAppUITest {
     private ViewInteraction checkMenuCommand(@StringRes int resId) {
         ViewInteraction view = onView(
                 allOf(withId(android.R.id.title),
-                        withText(resId),
-                        withParent(withParent(withId(android.R.id.content)))));
+                        withText(resId)));
         view.check(matches(isDisplayed()));
         return view;
     }
@@ -512,8 +516,15 @@ public class InAppUITest {
     private ViewInteraction checkMenuCommand(String label) {
         ViewInteraction view = onView(
                 allOf(withId(android.R.id.title),
-                        withText(label),
-                        withParent(withParent(withId(android.R.id.content)))));
+                        withText(label)));
+        view.check(matches(isDisplayed()));
+        return view;
+    }
+
+    private ViewInteraction checkMenuCommandPrefix(String labelPrefix) {
+        ViewInteraction view = onView(
+                allOf(withId(android.R.id.title),
+                        withText(startsWith(labelPrefix))));
         view.check(matches(isDisplayed()));
         return view;
     }

--- a/app/src/androidTest/java/com/onefishtwo/bbqtimer/InAppUITest.java
+++ b/app/src/androidTest/java/com/onefishtwo/bbqtimer/InAppUITest.java
@@ -329,14 +329,16 @@ public class InAppUITest {
         // FRAGILE: Changing the EditText to a Material EditText with a Clear (X) button made this
         // test fragile, where longClick() or doubleClick() alone fails to select the text.
         // doubleClick() is understandable since the first click shows the (X) and slides the text
-        // leftwards.
+        // leftwards. longClick() seems to work on phones but not on Nexus 7.
+        // Workaround: Put in multiple digits before doing longClick().
         alarmPeriodTextField.check(matches(not(hasFocus())));
         alarmPeriodTextField.perform(click());
         alarmPeriodTextField.check(matches(hasFocus()));
+        alarmPeriodTextField.perform(replaceText("111"));
         alarmPeriodTextField.perform(longClick());
         alarmPeriodTextField.check(matches(hasFocus()));
         alarmPeriodTextField.perform(typeTextIntoFocusedView("1:2:35\n"));
-        alarmPeriodTextField.check(matches(withText("1:02:35")));
+        alarmPeriodTextField.check(matches(withText("1:02:35"))); // expanded from "1:2:35"
         alarmPeriodTextField.check(matches(doesNotHaveFocus()));
 
         // FRAGILE: Adding the click() avoids on SDK 22 "SecurityException: Injecting to another
@@ -403,8 +405,10 @@ public class InAppUITest {
         // To aid manual testing, leave reminders enabled and a convenient alarm period set.
         enableRemindersToggle.perform(click());
         enableRemindersToggle.check(matches(isChecked()));
-        alarmPeriodTextField.perform(
-                click(), longClick(), typeTextIntoFocusedView("2\n"));
+        alarmPeriodTextField.perform(click());
+        alarmPeriodTextField.perform(replaceText("111"));
+        alarmPeriodTextField.perform(longClick());
+        alarmPeriodTextField.perform(typeTextIntoFocusedView("2\n"));
         alarmPeriodTextField.check(matches(withText("2")));
     }
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -31,7 +31,7 @@
         <activity
             android:name=".MainActivity"
             android:configChanges="keyboard|keyboardHidden|screenSize|mcc|mnc"
-            android:windowSoftInputMode="stateHidden|adjustPan"
+            android:windowSoftInputMode="adjustPan"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/com/onefishtwo/bbqtimer/LocaleUtils.java
+++ b/app/src/main/java/com/onefishtwo/bbqtimer/LocaleUtils.java
@@ -1,0 +1,52 @@
+package com.onefishtwo.bbqtimer;
+
+import android.os.Build;
+
+import java.util.Locale;
+import java.util.Set;
+
+public class LocaleUtils {
+    /** https://worldpopulationreview.com/country-rankings/countries-that-use-fahrenheit */
+    private static final Set<String> FAHRENHEIT_COUNTRIES = Set.of(
+            "US", // US
+            "BS", // Bahamas
+            "KY", // Cayman Islands
+            "LR", // Liberia
+            "PW", // Palau
+            "FM", // Federated States of Micronesia
+            "MH"  // Marshall Islands
+    );
+
+    /** Returns the default Locale for formatting dates, numbers, and/or currencies. */
+    public static Locale getFormatDefault() {
+        if (Build.VERSION.SDK_INT >= 24) {
+            return Locale.getDefault(Locale.Category.FORMAT);
+        } else {
+            return Locale.getDefault();
+        }
+    }
+
+    /** Indicates whether the locale should format temperatures in Fahrenheit °F rather than °C. */
+    public static boolean useFahrenheit(Locale locale) {
+        String country = locale.getCountry();
+        return FAHRENHEIT_COUNTRIES.contains(country);
+    }
+
+    /** Indicates whether to format temperatures in Fahrenheit °F rather than °C. */
+    public static boolean useFahrenheit() {
+        Locale locale = getFormatDefault();
+        return useFahrenheit(locale);
+    }
+
+    /** Format a temperature in Fahrenheit °F or Celsius °C, rounded to an integer. */
+    public static String formatTemperatureFromFahrenheit(double fahrenheit) {
+        Locale locale = getFormatDefault();
+
+        if (useFahrenheit(locale)) {
+            return String.format(locale, "%.0f°F", fahrenheit);
+        } else {
+            double celsius = (fahrenheit - 32.0) * 5 / 9;
+            return String.format(locale, "%.0f°C", celsius);
+        }
+    }
+}

--- a/app/src/main/java/com/onefishtwo/bbqtimer/MainActivity.java
+++ b/app/src/main/java/com/onefishtwo/bbqtimer/MainActivity.java
@@ -528,15 +528,6 @@ public class MainActivity extends FragmentActivity
         }
     }
 
-    /** Extracts the leading time token from the ***trimmed*** string. */
-    @NonNull
-    public static String extractLeadingToken(@NonNull String input) {
-        // TODO: Extract the first (:\d)+.
-        String[] tokens = input.split("\\s+", 2);
-
-        return tokens.length > 1 ? tokens[0] : input;
-    }
-
     /** The user clicked the button to open the "recipes" menu of alarm periods. */
     @UiThread
     public void onClickRecipeMenuButton(View v) {
@@ -559,7 +550,7 @@ public class MainActivity extends FragmentActivity
         for (String r : lines) { // Italicize the notes that follow each recipe's leading token.
             String recipe = r.trim();
             int recipeLength = recipe.length();
-            int tokenLength = extractLeadingToken(recipe).length();
+            int tokenLength = TimeCounter.lengthOfLeadingIntervalTime(recipe);
             SpannableString ss = new SpannableString(recipe);
 
             ss.setSpan(new StyleSpan(Typeface.ITALIC), tokenLength, recipeLength, 0);
@@ -598,16 +589,15 @@ public class MainActivity extends FragmentActivity
     @SuppressWarnings("SameReturnValue")
     @UiThread
     public boolean onRecipeMenuItemClick(MenuItem item) {
-        String itemTitle = item.getTitle().toString();
-
         if (item.getItemId() == R.id.edit_recipes) {
-            Log.i(TAG, "Clicked: " + itemTitle);
             showRecipeEditor();
             return true;
         }
 
-        String token = extractLeadingToken(itemTitle);
-        Log.i(TAG, "Picked: " + token);
+        String itemTitle = item.getTitle().toString();
+        int tokenLength = TimeCounter.lengthOfLeadingIntervalTime(itemTitle);
+        String token = itemTitle.substring(0, tokenLength);
+
         alarmPeriod.setText(token);
 
         // If the text field doesn't have focus, accept the new input now.

--- a/app/src/main/java/com/onefishtwo/bbqtimer/MainActivity.java
+++ b/app/src/main/java/com/onefishtwo/bbqtimer/MainActivity.java
@@ -70,17 +70,17 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
 import androidx.annotation.UiThread;
+import androidx.appcompat.app.AppCompatActivity;
 import androidx.constraintlayout.widget.ConstraintLayout;
 import androidx.core.app.NotificationManagerCompat;
 import androidx.core.app.TaskStackBuilder;
 import androidx.core.content.ContextCompat;
 import androidx.core.widget.TextViewCompat;
-import androidx.fragment.app.FragmentActivity;
 
 /**
  * The BBQ Timer's main activity.
  */
-public class MainActivity extends FragmentActivity
+public class MainActivity extends AppCompatActivity
         implements RecipeEditorDialogFragment.RecipeEditorDialogFragmentListener {
     private static final String TAG = "Main";
 

--- a/app/src/main/java/com/onefishtwo/bbqtimer/MainActivity.java
+++ b/app/src/main/java/com/onefishtwo/bbqtimer/MainActivity.java
@@ -198,6 +198,7 @@ public class MainActivity extends FragmentActivity
         super.onCreate(savedInstanceState);
         viewConfiguration = -1;
         notifier = new Notifier(this);
+        popupMenu = null;
 
         // View Binding has potential but it makes project inspections create a lot of spurious
         // warnings about unused resource IDs, methods, and method arguments.
@@ -365,6 +366,7 @@ public class MainActivity extends FragmentActivity
 
         if (popupMenu != null) {
             popupMenu.dismiss(); // avoid android.view.WindowLeaked PopupWindow$PopupViewContainer
+            // TODO: It still throws WindowLeaked PopupWindow$PopupDecorView on API 32.
             popupMenu = null;
         }
 
@@ -543,6 +545,7 @@ public class MainActivity extends FragmentActivity
 
         popupMenu.getMenuInflater().inflate(R.menu.recipe_menu, menu);
         popupMenu.setOnMenuItemClickListener(this::onRecipeMenuItemClick);
+        popupMenu.setOnDismissListener(this::onDismissRecipeMenu);
 
         MenuItem item = menu.findItem(R.id.edit_recipes);
         if (item != null) {
@@ -567,6 +570,7 @@ public class MainActivity extends FragmentActivity
     }
 
     /** Opens the recipe list editor dialog. */
+    @UiThread
     void showRecipeEditor() {
         String recipeLines = String.join("\n", state.getRecipes());
         RecipeEditorDialogFragment dialog = RecipeEditorDialogFragment.newInstance(recipeLines);
@@ -575,23 +579,26 @@ public class MainActivity extends FragmentActivity
     }
 
     @Override
+    @UiThread
     public void onEditorDialogPositiveClick(DialogInterface dialog, String text) {
         state.setRecipes(text);
         state.save(this);
-        Log.i(TAG, "Saved contents: " + text); // ***DEBUG***
     }
 
     @Override
+    @UiThread
     public void onEditorDialogNegativeClick(DialogInterface dialog) {
-        Log.i(TAG, "Cancelled the editor dialog"); // ***DEBUG***
+    }
+
+    @UiThread
+    public void onDismissRecipeMenu(PopupMenu menu) {
+        popupMenu = null;
     }
 
     @SuppressWarnings("SameReturnValue")
     @UiThread
     public boolean onRecipeMenuItemClick(MenuItem item) {
         String itemTitle = item.getTitle().toString();
-
-        popupMenu = null;
 
         if (item.getItemId() == R.id.edit_recipes) {
             Log.i(TAG, "Clicked: " + itemTitle);

--- a/app/src/main/java/com/onefishtwo/bbqtimer/MainActivity.java
+++ b/app/src/main/java/com/onefishtwo/bbqtimer/MainActivity.java
@@ -48,7 +48,6 @@ import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.inputmethod.InputMethodManager;
-import android.view.textclassifier.TextClassifier;
 import android.widget.Button;
 import android.widget.CheckBox;
 import android.widget.EditText;
@@ -227,7 +226,7 @@ public class MainActivity extends FragmentActivity
         enableReminders.setOnClickListener(this::onClickEnableRemindersToggle);
 
         // Set the TextClassifier *THEN* enable the CLEAR_TEXT (X) endIcon.
-        workaroundTextClassifier(alarmPeriod);
+        RecipeEditorDialogFragment.workaroundTextClassifier(alarmPeriod);
         TextInputLayout alarmPeriodLayout = findViewById(R.id.alarmPeriodLayout);
         alarmPeriodLayout.setEndIconMode(TextInputLayout.END_ICON_CLEAR_TEXT);
         alarmPeriodLayout.setStartIconOnClickListener(this::onClickRecipeMenuButton);
@@ -257,36 +256,6 @@ public class MainActivity extends FragmentActivity
         }
 
         logTheConfiguration(getResources().getConfiguration());
-    }
-
-    /**
-     * API 27: Work around an Android bug where double-clicking the EditText field would cause these
-     * log errors:
-     *
-     *   TextClassifierImpl: Error suggesting selection for text. No changes to selection suggested.
-     *     java.io.FileNotFoundException: No file for null locale
-     *         at android.view.textclassifier.TextClassifierImpl.getSmartSelection(TextClassifierImpl.java:208)
-     *         ...
-     *   TextClassifierImpl: Error getting assist info.
-     *     java.io.FileNotFoundException: No file for null locale
-     *         at android.view.textclassifier.TextClassifierImpl.getSmartSelection(TextClassifierImpl.java:208)
-     *         ...
-     *
-     * API > 27: Work around an Android bug that calls the TextClassifier on the main thread
-     * (UI thread) [e.g. when the user double-taps the EditText field, or long-presses it, or
-     * dismisses the soft keyboard when there's a text selection], causing this log warning even
-     * though no app code is on the call stack:
-     *
-     *   W/androidtc: TextClassifier called on main thread.
-     *
-     * To avoid the delay and potential ANR, just bypass the irrelevant TextClassifier. (This
-     * problem might not occur on API 28 - 29, but it's safer to do this uniformly.)
-     */
-    @SuppressWarnings("SpellCheckingInspection")
-    private static void workaroundTextClassifier(EditText editText) {
-        if (Build.VERSION.SDK_INT >= 27) {
-            editText.setTextClassifier(TextClassifier.NO_OP);
-        }
     }
 
     private void logTheConfiguration(@NonNull Configuration config) {

--- a/app/src/main/java/com/onefishtwo/bbqtimer/MainActivity.java
+++ b/app/src/main/java/com/onefishtwo/bbqtimer/MainActivity.java
@@ -569,7 +569,7 @@ public class MainActivity extends FragmentActivity
 
         alarmPeriod.setText(token);
 
-        // If the text field doesn't have focus, accept the new input now.
+        // Submit the input whether or not the text field has focus.
         processAlarmPeriodInput();
         return true;
     }
@@ -650,13 +650,16 @@ public class MainActivity extends FragmentActivity
         String input = text == null ? "" : text.toString();
         int newSeconds = TimeCounter.parseHhMmSs(input);
 
+        // Save the state change.
         if (newSeconds > 0 && newSeconds != state.getSecondsPerReminder()) {
             state.setSecondsPerReminder(newSeconds); // clips the value
             state.save(this);
             updateUI(); // update countdownDisplay, notifications, and widgets
-        } else {
-            displayAlarmPeriod();
         }
+
+        // Normalize the interval time text.
+        // [updateUI() does this only if the configuration changed.]
+        displayAlarmPeriod();
 
         defocusTextField(alarmPeriod);
     }
@@ -715,7 +718,7 @@ public class MainActivity extends FragmentActivity
                 : R.color.paused_timer_colors;
     }
 
-    /** Updates the elapsed time, alarm interval time, and the alarm count-down time displays. */
+    /** Updates the count-up (elapsed) time and alarm count-down time displays. */
     @UiThread
     private void displayTime() {
         Spanned formatted         = timer.formatHhMmSsFraction();

--- a/app/src/main/java/com/onefishtwo/bbqtimer/MainActivity.java
+++ b/app/src/main/java/com/onefishtwo/bbqtimer/MainActivity.java
@@ -551,7 +551,7 @@ public class MainActivity extends FragmentActivity
         if (item != null) {
             CharSequence title = item.getTitle();
             SpannableString ss = new SpannableString(title);
-            ss.setSpan(new StyleSpan(Typeface.ITALIC), 0, ss.length(), 0);
+            ss.setSpan(new StyleSpan(Typeface.BOLD), 0, ss.length(), 0);
             item.setTitle(ss);
         }
 

--- a/app/src/main/java/com/onefishtwo/bbqtimer/MainActivity.java
+++ b/app/src/main/java/com/onefishtwo/bbqtimer/MainActivity.java
@@ -230,7 +230,6 @@ public class MainActivity extends AppCompatActivity
         TextInputLayout alarmPeriodLayout = findViewById(R.id.alarmPeriodLayout);
         alarmPeriodLayout.setEndIconMode(TextInputLayout.END_ICON_CLEAR_TEXT);
         alarmPeriodLayout.setStartIconOnClickListener(this::onClickRecipeMenuButton);
-        // TODO: setStartIconContentDescription(), setStartIconOnLongClickListener()?
 
         // AutoSizeText works with android:maxLines="1" but not with android:singleLine="true".
         TextViewCompat.setAutoSizeTextTypeUniformWithConfiguration(countUpDisplay, 16,

--- a/app/src/main/java/com/onefishtwo/bbqtimer/RecipeEditorDialogFragment.java
+++ b/app/src/main/java/com/onefishtwo/bbqtimer/RecipeEditorDialogFragment.java
@@ -1,0 +1,126 @@
+package com.onefishtwo.bbqtimer;
+
+import android.app.Dialog;
+import android.content.Context;
+import android.content.DialogInterface;
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.widget.EditText;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AlertDialog;
+import androidx.fragment.app.DialogFragment;
+
+/**
+ * A Dialog to edit the recipe list.
+ * </p>
+ * The FragmentActivity that instantiates a RecipeEditorDialogFragment must implement
+ * RecipeEditorDialogFragmentListener.
+ */
+public class RecipeEditorDialogFragment extends DialogFragment {
+    public static final String TAG = "RecipeEditor";
+    private static final String KEY_TEXT_CONTENTS = "Text";
+    static final String FALLBACK_CONTENTS = ":30\n1\n1:30\n2\n";
+
+    /**
+     * The FragmentActivity that instantiates a RecipeEditorDialogFragment must implement this
+     * Listener interface so it can get the edited results. */
+    public interface RecipeEditorDialogFragmentListener {
+        void onEditorDialogPositiveClick(DialogInterface dialog, String text);
+        void onEditorDialogNegativeClick(DialogInterface dialog);
+        // Override onDismiss() to notice all dismissal cases? hideKeyboard() doesn't work there.
+        // Maybe it gets called too late for that.
+    }
+
+    private RecipeEditorDialogFragmentListener listener;
+    private EditText textField;
+
+    /** Creates and initializes a recipe list editor dialog. */
+    public static RecipeEditorDialogFragment newInstance(String text) {
+        RecipeEditorDialogFragment dialog = new RecipeEditorDialogFragment();
+        Bundle bundle = new Bundle();
+
+        // The text is stored in the Arguments Bundle so it's available on re-create.
+        // TODO: Save contents at some juncture?
+        if (text.trim().length() == 0) {
+            text = FALLBACK_CONTENTS;
+        }
+        bundle.putString(KEY_TEXT_CONTENTS, text);
+        dialog.setArguments(bundle);
+        return dialog;
+    }
+
+    @NonNull
+    public String getInitContents() {
+        Bundle bundle = getArguments();
+
+        if (bundle == null) {
+            return FALLBACK_CONTENTS;
+        } else {
+            String string = bundle.getString(KEY_TEXT_CONTENTS);
+            return string == null ? FALLBACK_CONTENTS : string;
+        }
+    }
+
+    @Override
+    public void onAttach(@NonNull Context context) {
+        super.onAttach(context);
+        try {
+            listener = (RecipeEditorDialogFragmentListener) context;
+        } catch (ClassCastException e) {
+            throw new ClassCastException(
+                    context + " expected to implement RecipeEditorDialogFragmentListener");
+        }
+    }
+
+    private void hideKeyboard(@Nullable View v) {
+        MainActivity.hideKeyboard(requireActivity(), v);
+        // TODO: v.clearFocus() to avoid showing keyboard again if you open the app from the background?
+    }
+
+    /**
+     * The TextEdit field's focus changed, e.g. by TAB, arrow keys, or view.clearFocus().
+     * If it lost focus, hide the soft keyboard to ensure it's not hiding the Save & Cancel buttons.
+     */
+    private void onEditTextFocusChange(View view, boolean nowHasFocus) {
+        if (!nowHasFocus) {
+            hideKeyboard(view);
+        }
+    }
+
+    @NonNull
+    @Override
+    public Dialog onCreateDialog(@Nullable Bundle savedInstanceState) {
+        AlertDialog.Builder builder = new AlertDialog.Builder(requireActivity(),
+                R.style.Theme_Material3_DayNight_Dialog); // TODO: Pass in a theme ID? R.style.Theme_Material_Dialog_Alert? Theme_Material3_DayNight_Dialog? Theme_AppCompat_Dialog_Alert? Theme_Material3_Dark_Dialog_Alert?
+        LayoutInflater inflater = requireActivity().getLayoutInflater();
+        View content = inflater.inflate(R.layout.dialog_edit_recipes, null);
+        // "To ensure consistent styling, the custom view should be inflated or constructed using
+        // the alert dialog's themed context obtained via getContext()."
+
+        builder.setTitle(R.string.edit_list_title)
+                .setView(content);
+
+        textField = content.findViewById(R.id.recipes_text_field);
+        textField.setOnFocusChangeListener(this::onEditTextFocusChange);
+
+        if (textField != null) {
+            textField.setText(getInitContents());
+
+            builder.setPositiveButton(R.string.save_edits, (dialog, which) -> {
+                        hideKeyboard(textField);
+                        listener.onEditorDialogPositiveClick(
+                                dialog, textField.getText().toString());
+                    })
+                    .setNegativeButton(R.string.cancel_edits, (dialog, which) -> {
+                        hideKeyboard(textField);
+                        listener.onEditorDialogNegativeClick(dialog);
+                        dialog.cancel();
+                    });
+        }
+
+        return builder.create();
+    }
+}

--- a/app/src/main/java/com/onefishtwo/bbqtimer/RecipeEditorDialogFragment.java
+++ b/app/src/main/java/com/onefishtwo/bbqtimer/RecipeEditorDialogFragment.java
@@ -43,7 +43,7 @@ public class RecipeEditorDialogFragment extends DialogFragment {
         Bundle bundle = new Bundle();
 
         // The text is stored in the Arguments Bundle so it's available on re-create.
-        // TODO: Save contents at some juncture?
+        // TODO: Save contents in onPause() or onDestroy()?
         if (text.trim().length() == 0) {
             text = FALLBACK_CONTENTS;
         }
@@ -94,7 +94,7 @@ public class RecipeEditorDialogFragment extends DialogFragment {
     @Override
     public Dialog onCreateDialog(@Nullable Bundle savedInstanceState) {
         AlertDialog.Builder builder = new AlertDialog.Builder(requireActivity(),
-                R.style.Theme_Material3_DayNight_Dialog); // TODO: Pass in a theme ID? R.style.Theme_Material_Dialog_Alert? Theme_Material3_DayNight_Dialog? Theme_AppCompat_Dialog_Alert? Theme_Material3_Dark_Dialog_Alert?
+                R.style.ThemeOverlay_Material3_TextInputEditText_OutlinedBox);
         LayoutInflater inflater = requireActivity().getLayoutInflater();
         View content = inflater.inflate(R.layout.dialog_edit_recipes, null);
         // "To ensure consistent styling, the custom view should be inflated or constructed using
@@ -105,6 +105,11 @@ public class RecipeEditorDialogFragment extends DialogFragment {
 
         textField = content.findViewById(R.id.recipes_text_field);
         textField.setOnFocusChangeListener(this::onEditTextFocusChange);
+
+        // Workaround: The XML scrolling attributes don't work very well.
+        textField.setHorizontallyScrolling(true);
+        textField.setHorizontalScrollBarEnabled(true);
+        textField.setScrollbarFadingEnabled(false);
 
         if (textField != null) {
             textField.setText(getInitContents());

--- a/app/src/main/java/com/onefishtwo/bbqtimer/RecipeEditorDialogFragment.java
+++ b/app/src/main/java/com/onefishtwo/bbqtimer/RecipeEditorDialogFragment.java
@@ -124,15 +124,24 @@ public class RecipeEditorDialogFragment extends DialogFragment {
         return builder.create();
     }
 
-    /** DialogInterface.OnClickListener for the "Save" button. */
+    /**
+     * DialogInterface.OnClickListener for the "Save" button: Hides the soft keyboard and returns
+     * the edited text to the Activity. Returns the default text if the edited text is empty.
+     */
     private void saveEdits(DialogInterface dialog, int which) {
+        String result = textField.getText().toString();
+
+        if (result.trim().length() == 0) {
+            result = ApplicationState.getDefaultRecipes(textField.getContext());
+        }
+
         hideKeyboard(textField);
-        listener.onEditorDialogPositiveClick(dialog, textField.getText().toString());
+        listener.onEditorDialogPositiveClick(dialog, result);
     }
 
     /** DialogInterface.OnClickListener for the "Reset" button. */
     private void resetEdits(DialogInterface dialog, int which) {
-        textField.setText(ApplicationState.getDefaultRecipes(textField.getContext()));
+        textField.setText("");
         saveEdits(dialog, which);
     }
 

--- a/app/src/main/java/com/onefishtwo/bbqtimer/RecipeEditorDialogFragment.java
+++ b/app/src/main/java/com/onefishtwo/bbqtimer/RecipeEditorDialogFragment.java
@@ -129,6 +129,10 @@ public class RecipeEditorDialogFragment extends DialogFragment {
     @NonNull
     @Override
     public Dialog onCreateDialog(@Nullable Bundle savedInstanceState) {
+        // This theme shows the dialog full-width and scrolling in a way that the soft keyboard
+        // nicely resizes it, keeping the Reset/Cancel/Save buttons visible and accessible.
+        // Using MaterialAlertDialogBuilder doesn't seem to accomplish that, but maybe it's a
+        // question of the right theme.
         AlertDialog.Builder builder = new AlertDialog.Builder(requireActivity(),
                 R.style.ThemeOverlay_Material3_TextInputEditText_OutlinedBox);
         LayoutInflater inflater = requireActivity().getLayoutInflater();

--- a/app/src/main/java/com/onefishtwo/bbqtimer/RecipeEditorDialogFragment.java
+++ b/app/src/main/java/com/onefishtwo/bbqtimer/RecipeEditorDialogFragment.java
@@ -36,8 +36,8 @@ public class RecipeEditorDialogFragment extends DialogFragment {
         void onEditorDialogPositiveClick(DialogInterface dialog, String text);
         @SuppressWarnings("EmptyMethod")
         void onEditorDialogNegativeClick(DialogInterface dialog);
-        // Override onDismiss() to notice all dismissal cases? hideKeyboard() doesn't work there.
-        // Maybe it gets called too late for that.
+        // Override onDismiss() to notice all dismissal cases? onDismiss() calling hideKeyboard()
+        // doesn't work. Maybe it gets called too late.
     }
 
     private RecipeEditorDialogFragmentListener listener;
@@ -164,24 +164,26 @@ public class RecipeEditorDialogFragment extends DialogFragment {
     }
 
     /**
-     * DialogInterface.OnClickListener for the "Save" button: Hides the soft keyboard and returns
-     * the edited text to the Activity. Returns the default text if the edited text is empty.
+     * <li>Hides the soft keyboard.
+     * <li>Passes the given recipes (or if blank, the default recipes) to the listener.
      */
-    private void saveEdits(DialogInterface dialog, int which) {
-        String result = textField.getText().toString();
-
-        if (result.trim().length() == 0) {
-            result = ApplicationState.getDefaultRecipes(textField.getContext());
-        }
-
+    private void saveText(DialogInterface dialog, String recipes) {
         hideKeyboard(textField);
-        listener.onEditorDialogPositiveClick(dialog, result);
+
+        if (recipes.trim().length() == 0) {
+            recipes = ApplicationState.getDefaultRecipes(textField.getContext());
+        }
+        listener.onEditorDialogPositiveClick(dialog, recipes);
+    }
+
+    /** DialogInterface.OnClickListener for the "Save" button. */
+    private void saveEdits(DialogInterface dialog, int which) {
+        saveText(dialog, textField.getText().toString());
     }
 
     /** DialogInterface.OnClickListener for the "Reset" button. */
     private void resetEdits(DialogInterface dialog, int which) {
-        textField.setText("");
-        saveEdits(dialog, which);
+        saveText(dialog, "");
     }
 
     /** DialogInterface.OnClickListener for the "Cancel" button. */

--- a/app/src/main/java/com/onefishtwo/bbqtimer/RecipeEditorDialogFragment.java
+++ b/app/src/main/java/com/onefishtwo/bbqtimer/RecipeEditorDialogFragment.java
@@ -8,6 +8,8 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.EditText;
 
+import com.onefishtwo.bbqtimer.state.ApplicationState;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
@@ -114,18 +116,30 @@ public class RecipeEditorDialogFragment extends DialogFragment {
         if (textField != null) {
             textField.setText(getInitContents());
 
-            builder.setPositiveButton(R.string.save_edits, (dialog, which) -> {
-                        hideKeyboard(textField);
-                        listener.onEditorDialogPositiveClick(
-                                dialog, textField.getText().toString());
-                    })
-                    .setNegativeButton(R.string.cancel_edits, (dialog, which) -> {
-                        hideKeyboard(textField);
-                        listener.onEditorDialogNegativeClick(dialog);
-                        dialog.cancel();
-                    });
+            builder.setPositiveButton(R.string.save_edits, this::saveEdits)
+                    .setNeutralButton(R.string.reset, this::resetEdits)
+                    .setNegativeButton(R.string.cancel_edits, this::cancelEdits);
         }
 
         return builder.create();
+    }
+
+    /** DialogInterface.OnClickListener for the "Save" button. */
+    private void saveEdits(DialogInterface dialog, int which) {
+        hideKeyboard(textField);
+        listener.onEditorDialogPositiveClick(dialog, textField.getText().toString());
+    }
+
+    /** DialogInterface.OnClickListener for the "Reset" button. */
+    private void resetEdits(DialogInterface dialog, int which) {
+        textField.setText(ApplicationState.getDefaultRecipes(textField.getContext()));
+        saveEdits(dialog, which);
+    }
+
+    /** DialogInterface.OnClickListener for the "Cancel" button. */
+    private void cancelEdits(DialogInterface dialog, int which) {
+        hideKeyboard(textField);
+        listener.onEditorDialogNegativeClick(dialog);
+        dialog.cancel();
     }
 }

--- a/app/src/main/java/com/onefishtwo/bbqtimer/RecipeEditorDialogFragment.java
+++ b/app/src/main/java/com/onefishtwo/bbqtimer/RecipeEditorDialogFragment.java
@@ -33,7 +33,9 @@ public class RecipeEditorDialogFragment extends DialogFragment {
      * Listener interface so it can get the edited results. */
     @SuppressWarnings("unused")
     public interface RecipeEditorDialogFragmentListener {
+        /** The user changed (edited or reset) the recipes. */
         void onEditorDialogPositiveClick(DialogInterface dialog, String text);
+        /** The user cancelled the dialog; no change to the recipes. */
         @SuppressWarnings("EmptyMethod")
         void onEditorDialogNegativeClick(DialogInterface dialog);
         // Override onDismiss() to notice all dismissal cases? onDismiss() calling hideKeyboard()

--- a/app/src/main/java/com/onefishtwo/bbqtimer/TimeCounter.java
+++ b/app/src/main/java/com/onefishtwo/bbqtimer/TimeCounter.java
@@ -383,7 +383,8 @@ public class TimeCounter {
     /**
      * Formats a millisecond duration in the compact format that parseHhMmSs supports, that is,
      * h:mm:ss or m:ss or m, e.g. "7" rather than "07:00".
-     *
+     * Format 60 minutes as "60" instead of "1:00:00".
+     * <p/>
      * Derived from {@link DateUtils#formatElapsedTime(long)}.
      */
     public static String formatHhMmSsCompact(long elapsedMilliseconds) {

--- a/app/src/main/java/com/onefishtwo/bbqtimer/TimeCounter.java
+++ b/app/src/main/java/com/onefishtwo/bbqtimer/TimeCounter.java
@@ -31,6 +31,7 @@ import java.text.FieldPosition;
 import java.text.NumberFormat;
 import java.util.Formatter;
 import java.util.Locale;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import androidx.annotation.NonNull;
@@ -52,6 +53,13 @@ public class TimeCounter {
      * a physical keyboard, restricting typed or pasted characters to [0-9:apm] (maybe more).
      */
     static final Pattern HMS_SEPARATOR = Pattern.compile(":");
+
+    /**
+     * Pattern to extract the interval time at the start of a "recipe" line.
+     * Includes leading spaces so the match length indicates where the following text (notes) begin,
+     * so they can get italicized.
+     */
+    static final Pattern INTERVAL_TIME_IN_RECIPE = Pattern.compile("\\s*[\\d:]+");
 
     /**
      * Injectable mocks of DateUtils.formatElapsedTime() and Html.fromHtml() SINCE THE UNIT TEST
@@ -422,8 +430,8 @@ public class TimeCounter {
     }
 
     /**
-     * Parses a time duration in the form: hh:mm:ss, mm:ss, mm. Each field has zero or more digits,
-     * but commonly two digits. dd[:dd[:dd]]. This is forgiving but it returns -1 if the input isn't
+     * Parses a time duration in the form: h:m:s|m:s|m. Each field has zero or more digits,
+     * but commonly two digits, dd[:dd[:dd]]. This is forgiving but it returns -1 if the input isn't
      * in a recognized format. All spaces get squeezed out. The field separator is ":".
      * <p/>
      * Returns the parsed number of seconds, or -1 if the input is not in the right format.
@@ -457,6 +465,18 @@ public class TimeCounter {
         }
 
         return result;
+    }
+
+    /**
+     * Parses out the leading interval-time token from the recipe string and returns its length.
+     * The token includes any leading spaces so the match length indicates where the following text
+     * (the notes) begin, so they can get italicized.
+     */
+    public static int lengthOfLeadingIntervalTime(String recipe) {
+        Matcher matcher = INTERVAL_TIME_IN_RECIPE.matcher(recipe);
+        boolean matched = matcher.lookingAt();
+
+        return matched ? matcher.end() : 0;
     }
 
     @NonNull

--- a/app/src/main/java/com/onefishtwo/bbqtimer/state/ApplicationState.java
+++ b/app/src/main/java/com/onefishtwo/bbqtimer/state/ApplicationState.java
@@ -21,8 +21,10 @@ package com.onefishtwo.bbqtimer.state;
 
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.content.res.Resources;
 import android.util.Log;
 
+import com.onefishtwo.bbqtimer.R;
 import com.onefishtwo.bbqtimer.TimeCounter;
 
 import androidx.annotation.NonNull;
@@ -41,6 +43,9 @@ public class ApplicationState {
     public static final int MINIMUM_ALARM_SECONDS = 5;
     public static final int MAXIMUM_ALARM_SECONDS = 100 * 3600 - 1; // 99:59:59
 
+    /** Locale-independent, resource-independent fallback for the recipe list. */
+    public static final String FALLBACK_RECIPES = ":30\n1\n1:30\n2\n3\n4\n5\n6\n7\n8\n9\n10";
+
     /** PERSISTENT STATE filename. */
     private static final String APPLICATION_PREF_FILE = "BBQ_Timer_Prefs";
 
@@ -48,6 +53,7 @@ public class ApplicationState {
     private static final String PREF_MAIN_ACTIVITY_IS_VISIBLE = "App_mainActivityIsVisible";
     private static final String PREF_ENABLE_REMINDERS = "App_enableReminders";
     private static final String PREF_SECONDS_PER_REMINDER = "App_secondsPerReminder";
+    private static final String PREF_RECIPES = "App_recipes";
 
     private static ApplicationState sharedInstance;
 
@@ -55,6 +61,7 @@ public class ApplicationState {
     private boolean mainActivityIsVisible; // between onStart() .. onStop()
     private boolean enableReminders;
     private int secondsPerReminder;
+    private String recipes = FALLBACK_RECIPES;
 
     /**
      * Returns the shared instance, using context to load the persistent state if needed and to save
@@ -110,6 +117,14 @@ public class ApplicationState {
         int secs              = prefs.getInt(PREF_SECONDS_PER_REMINDER, 5 * 60);
         secondsPerReminder    = boundIntervalTimeSeconds(secs);
 
+        String defaultRecipes;
+        try {
+            defaultRecipes = context.getString(R.string.recipes);
+        } catch (Resources.NotFoundException e) {
+            defaultRecipes = FALLBACK_RECIPES;
+        }
+        recipes = prefs.getString(PREF_RECIPES, defaultRecipes);
+
         return needToSave;
     }
 
@@ -123,6 +138,7 @@ public class ApplicationState {
         prefsEditor.putBoolean(PREF_MAIN_ACTIVITY_IS_VISIBLE, mainActivityIsVisible);
         prefsEditor.putBoolean(PREF_ENABLE_REMINDERS, enableReminders);
         prefsEditor.putInt(PREF_SECONDS_PER_REMINDER, secondsPerReminder);
+        prefsEditor.putString(PREF_RECIPES, recipes);
         prefsEditor.apply();
     }
 
@@ -207,5 +223,16 @@ public class ApplicationState {
     @NonNull
     public String formatIntervalTimeHhMmSsCompact() {
         return TimeCounter.formatHhMmSsCompact(getMillisecondsPerReminder());
+    }
+
+    /** Gets the recipe text. */
+    @NonNull
+    public String getRecipes() {
+        return recipes;
+    }
+
+    /** Sets the recipe text. */
+    public void setRecipes(@NonNull String text) {
+        recipes = text;
     }
 }

--- a/app/src/main/java/com/onefishtwo/bbqtimer/state/ApplicationState.java
+++ b/app/src/main/java/com/onefishtwo/bbqtimer/state/ApplicationState.java
@@ -117,15 +117,21 @@ public class ApplicationState {
         int secs              = prefs.getInt(PREF_SECONDS_PER_REMINDER, 5 * 60);
         secondsPerReminder    = boundIntervalTimeSeconds(secs);
 
-        String defaultRecipes;
-        try {
-            defaultRecipes = context.getString(R.string.recipes);
-        } catch (Resources.NotFoundException e) {
-            defaultRecipes = FALLBACK_RECIPES;
-        }
+        String defaultRecipes = getDefaultRecipes(context);
         recipes = prefs.getString(PREF_RECIPES, defaultRecipes);
 
         return needToSave;
+    }
+
+    /** Returns the default recipes text. */
+    // TODO: If LocaleData.getMeasurementSystem(ULocale locale) == LocaleData.MeasurementSystem.US
+    //  use °F else °C.
+    public static String getDefaultRecipes(@NonNull Context context) {
+        try {
+            return context.getString(R.string.recipes);
+        } catch (Resources.NotFoundException e) {
+            return FALLBACK_RECIPES;
+        }
     }
 
     /** Saves persistent state using context. */

--- a/app/src/main/java/com/onefishtwo/bbqtimer/state/ApplicationState.java
+++ b/app/src/main/java/com/onefishtwo/bbqtimer/state/ApplicationState.java
@@ -24,6 +24,7 @@ import android.content.SharedPreferences;
 import android.content.res.Resources;
 import android.util.Log;
 
+import com.onefishtwo.bbqtimer.LocaleUtils;
 import com.onefishtwo.bbqtimer.R;
 import com.onefishtwo.bbqtimer.TimeCounter;
 
@@ -123,12 +124,12 @@ public class ApplicationState {
         return needToSave;
     }
 
-    /** Returns the default recipes text. */
-    // TODO: If LocaleData.getMeasurementSystem(ULocale locale) == LocaleData.MeasurementSystem.US
-    //  use °F else °C.
+    /** Returns the default recipes text using °F or °C per the current locale. */
     public static String getDefaultRecipes(@NonNull Context context) {
         try {
-            return context.getString(R.string.recipes);
+            return context.getString(R.string.recipes,
+                    LocaleUtils.formatTemperatureFromFahrenheit(145),
+                    LocaleUtils.formatTemperatureFromFahrenheit(165));
         } catch (Resources.NotFoundException e) {
             return FALLBACK_RECIPES;
         }

--- a/app/src/main/res/drawable/ic_baseline_arrow_drop_up_48.xml
+++ b/app/src/main/res/drawable/ic_baseline_arrow_drop_up_48.xml
@@ -1,0 +1,5 @@
+<vector android:height="48dp" android:tint="#FFFFFF"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="48dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M7,14l5,-5 5,5z"/>
+</vector>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -38,6 +38,8 @@
         android:minHeight="@dimen/countdown_text_size"
         android:layout_marginEnd="@dimen/button_padding"
         android:focusable="true"
+        android:nextFocusForward="@id/pauseResumeButton"
+        android:nextFocusRight="@id/pauseResumeButton"
         android:gravity="right|center_vertical"
         android:maxLines="1"
         android:paddingLeft="@dimen/countdown_padding"
@@ -52,6 +54,11 @@
         app:layout_constraintTop_toTopOf="@id/buttonBar"
         app:layout_constraintHorizontal_bias="1" />
 
+    <!-- Workaround: The focusable*=true attributes make this view focusable so alarmPeriod won't
+         automatically grab focus when the Activity starts or resumes on API ≤ 27.
+         This is better than calling defocusTextField(alarmPeriod) in onResume() since the latter
+         breaks the second and later uses of the adjustPan feature (pan the window contents to fit
+         the text field with soft keyboard), at least on API 22-23. -->
     <LinearLayout
         android:id="@+id/buttonBar"
         android:layout_width="wrap_content"
@@ -59,6 +66,8 @@
         android:background="@color/grayer"
         android:gravity="center_vertical|right"
         android:orientation="horizontal"
+        android:focusable="true"
+        android:focusableInTouchMode="true"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toBottomOf="@id/countUpDisplay">
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -5,18 +5,17 @@
     android:id="@+id/main_container"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:focusable="false"
     android:paddingLeft="@dimen/activity_horizontal_margin"
     android:paddingTop="@dimen/activity_vertical_margin"
-    android:paddingRight="@dimen/activity_horizontal_margin"
     android:paddingBottom="@dimen/activity_vertical_margin"
+    android:paddingRight="@dimen/activity_horizontal_margin"
+    android:focusable="false"
     tools:context="com.onefishtwo.bbqtimer.MainActivity">
 
     <TextView
         android:id="@+id/countUpDisplay"
         android:layout_width="0dp"
         android:layout_height="@dimen/display_text_view_adjusted_height"
-        android:background="?attr/selectableItemBackground"
         android:clickable="true"
         android:ellipsize="end"
         android:focusable="true"
@@ -24,6 +23,7 @@
         android:maxLines="1"
         android:text="@string/time0"
         android:textColor="@color/running_timer_colors"
+        android:background="?attr/selectableItemBackground"
         android:textSize="@dimen/display_text_size"
         android:typeface="sans"
         app:layout_constraintEnd_toEndOf="parent"
@@ -35,22 +35,22 @@
         android:id="@+id/countdownDisplay"
         android:layout_width="0dp"
         android:layout_height="0dp"
+        android:minHeight="@dimen/countdown_text_size"
         android:layout_marginEnd="@dimen/button_padding"
-        android:background="?attr/selectableItemBackground"
         android:focusable="true"
         android:gravity="right|center_vertical"
         android:maxLines="1"
-        android:minHeight="@dimen/countdown_text_size"
         android:paddingLeft="@dimen/countdown_padding"
         android:paddingRight="@dimen/countdown_padding"
         android:text="@string/time0"
-        android:textColor="@color/countdown_colors"
         android:textSize="@dimen/countdown_text_size"
+        android:textColor="@color/countdown_colors"
+        android:background="?attr/selectableItemBackground"
         app:layout_constraintBottom_toBottomOf="@id/buttonBar"
         app:layout_constraintEnd_toStartOf="@id/buttonBar"
-        app:layout_constraintHorizontal_bias="1"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="@id/buttonBar" />
+        app:layout_constraintTop_toTopOf="@id/buttonBar"
+        app:layout_constraintHorizontal_bias="1" />
 
     <LinearLayout
         android:id="@+id/buttonBar"
@@ -131,33 +131,33 @@
 
     <com.google.android.material.textfield.TextInputLayout
         android:id="@+id/alarmPeriodLayout"
-        style="@style/Widget.Material3.TextInputLayout.OutlinedBox.Dense"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/fold_margin"
+        style="@style/Widget.Material3.TextInputLayout.OutlinedBox.Dense"
         android:hint="@string/interval_hint"
         app:hintTextAppearance="@style/HintTextAppearance"
         app:startIconDrawable="@drawable/ic_baseline_arrow_drop_up_48"
-        app:layout_constraintBottom_toBottomOf="@+id/enableReminders"
         app:layout_constraintTop_toBottomOf="@id/fold"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintVertical_bias="0.5">
+        app:layout_constraintBottom_toBottomOf="@+id/enableReminders"
+        app:layout_constraintVertical_bias="0.5"
+        app:layout_constraintEnd_toEndOf="parent">
 
         <com.onefishtwo.bbqtimer.EditText2
             android:id="@+id/alarmPeriod"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:gravity="right"
-            android:importantForAutofill="no"
-            android:inputType="time"
-            android:lines="1"
-            android:maxLength="9"
-            android:maxLines="1"
             android:minWidth="@dimen/alarm_period_min_width"
+            android:gravity="right"
+            android:maxLines="1"
+            android:lines="1"
             android:paddingLeft="@dimen/small_button_padding"
+            android:inputType="time"
+            android:maxLength="9"
             android:text="@string/widget_preview_countdown"
+            android:textSize="@dimen/controls_text_size"
             android:textColor="?android:attr/textColorPrimary"
-            android:textSize="@dimen/controls_text_size" />
+            android:importantForAutofill="no" />
 
     </com.google.android.material.textfield.TextInputLayout>
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -54,11 +54,24 @@
         app:layout_constraintTop_toTopOf="@id/buttonBar"
         app:layout_constraintHorizontal_bias="1" />
 
-    <!-- Workaround: The focusable*=true attributes make this view focusable so alarmPeriod won't
-         automatically grab focus when the Activity starts or resumes on API ≤ 27.
-         This is better than calling defocusTextField(alarmPeriod) in onResume() since the latter
-         breaks the second and later uses of the adjustPan feature (pan the window contents to fit
-         the text field with soft keyboard), at least on API 22-23. -->
+    <!-- Workaround: The focusable*=true attributes make this empty view focusable enough that
+         alarmPeriod won't automatically get focus when the Activity starts or resumes on API ≤ 27.
+
+         The empty view is in the keyboard navigation sequence for API ≤ 27, but unobtrusively at
+         the start of the sequence.
+
+         This is better than calling defocusTextField(alarmPeriod) in onResume() since it doesn't
+         break the second and later uses of the adjustPan feature (pan the window contents to fit
+         the text field and the soft keyboard), at least on API 22-23. -->
+    <LinearLayout
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="@color/grayer"
+        android:focusable="true"
+        android:focusableInTouchMode="true"
+        app:layout_constraintEnd_toStartOf="@+id/countUpDisplay"
+        app:layout_constraintTop_toTopOf="parent"/>
+
     <LinearLayout
         android:id="@+id/buttonBar"
         android:layout_width="wrap_content"
@@ -66,8 +79,6 @@
         android:background="@color/grayer"
         android:gravity="center_vertical|right"
         android:orientation="horizontal"
-        android:focusable="true"
-        android:focusableInTouchMode="true"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toBottomOf="@id/countUpDisplay">
 
@@ -161,7 +172,7 @@
             android:gravity="right"
             android:maxLines="1"
             android:lines="1"
-            android:paddingLeft="@dimen/small_button_padding"
+            android:paddingLeft="0dp"
             android:inputType="time"
             android:maxLength="9"
             android:text="@string/widget_preview_countdown"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -5,17 +5,18 @@
     android:id="@+id/main_container"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:focusable="false"
     android:paddingLeft="@dimen/activity_horizontal_margin"
     android:paddingTop="@dimen/activity_vertical_margin"
-    android:paddingBottom="@dimen/activity_vertical_margin"
     android:paddingRight="@dimen/activity_horizontal_margin"
-    android:focusable="false"
+    android:paddingBottom="@dimen/activity_vertical_margin"
     tools:context="com.onefishtwo.bbqtimer.MainActivity">
 
     <TextView
         android:id="@+id/countUpDisplay"
         android:layout_width="0dp"
         android:layout_height="@dimen/display_text_view_adjusted_height"
+        android:background="?attr/selectableItemBackground"
         android:clickable="true"
         android:ellipsize="end"
         android:focusable="true"
@@ -23,7 +24,6 @@
         android:maxLines="1"
         android:text="@string/time0"
         android:textColor="@color/running_timer_colors"
-        android:background="?attr/selectableItemBackground"
         android:textSize="@dimen/display_text_size"
         android:typeface="sans"
         app:layout_constraintEnd_toEndOf="parent"
@@ -35,22 +35,22 @@
         android:id="@+id/countdownDisplay"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        android:minHeight="@dimen/countdown_text_size"
         android:layout_marginEnd="@dimen/button_padding"
+        android:background="?attr/selectableItemBackground"
         android:focusable="true"
         android:gravity="right|center_vertical"
         android:maxLines="1"
+        android:minHeight="@dimen/countdown_text_size"
         android:paddingLeft="@dimen/countdown_padding"
         android:paddingRight="@dimen/countdown_padding"
         android:text="@string/time0"
-        android:textSize="@dimen/countdown_text_size"
         android:textColor="@color/countdown_colors"
-        android:background="?attr/selectableItemBackground"
+        android:textSize="@dimen/countdown_text_size"
         app:layout_constraintBottom_toBottomOf="@id/buttonBar"
         app:layout_constraintEnd_toStartOf="@id/buttonBar"
+        app:layout_constraintHorizontal_bias="1"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="@id/buttonBar"
-        app:layout_constraintHorizontal_bias="1" />
+        app:layout_constraintTop_toTopOf="@id/buttonBar" />
 
     <LinearLayout
         android:id="@+id/buttonBar"
@@ -104,7 +104,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         app:barrierDirection="bottom"
-        app:constraint_referenced_ids="countdownDisplay,buttonBar"/>
+        app:constraint_referenced_ids="countdownDisplay,buttonBar" />
 
     <CheckBox
         android:id="@+id/enableReminders"
@@ -131,32 +131,34 @@
 
     <com.google.android.material.textfield.TextInputLayout
         android:id="@+id/alarmPeriodLayout"
+        style="@style/Widget.Material3.TextInputLayout.OutlinedBox.Dense"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/fold_margin"
-        style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.Dense"
         android:hint="@string/interval_hint"
         app:hintTextAppearance="@style/HintTextAppearance"
-        app:layout_constraintTop_toBottomOf="@id/fold"
+        app:startIconDrawable="@drawable/ic_baseline_arrow_drop_up_48"
         app:layout_constraintBottom_toBottomOf="@+id/enableReminders"
-        app:layout_constraintVertical_bias="0.5"
-        app:layout_constraintEnd_toEndOf="parent">
+        app:layout_constraintTop_toBottomOf="@id/fold"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintVertical_bias="0.5">
 
         <com.onefishtwo.bbqtimer.EditText2
             android:id="@+id/alarmPeriod"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:minWidth="@dimen/alarm_period_min_width"
             android:gravity="right"
-            android:maxLines="1"
-            android:lines="1"
-            android:paddingLeft="@dimen/small_button_padding"
+            android:importantForAutofill="no"
             android:inputType="time"
+            android:lines="1"
             android:maxLength="9"
+            android:maxLines="1"
+            android:minWidth="@dimen/alarm_period_min_width"
+            android:paddingLeft="@dimen/small_button_padding"
             android:text="@string/widget_preview_countdown"
-            android:textSize="@dimen/controls_text_size"
             android:textColor="?android:attr/textColorPrimary"
-            android:importantForAutofill="no" />
+            android:textSize="@dimen/controls_text_size" />
+
     </com.google.android.material.textfield.TextInputLayout>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -138,6 +138,7 @@
         android:hint="@string/interval_hint"
         app:hintTextAppearance="@style/HintTextAppearance"
         app:startIconDrawable="@drawable/ic_baseline_arrow_drop_up_48"
+        app:startIconContentDescription="@string/intervals_menu"
         app:layout_constraintTop_toBottomOf="@id/fold"
         app:layout_constraintBottom_toBottomOf="@+id/enableReminders"
         app:layout_constraintVertical_bias="0.5"

--- a/app/src/main/res/layout/dialog_edit_recipes.xml
+++ b/app/src/main/res/layout/dialog_edit_recipes.xml
@@ -18,7 +18,6 @@
         android:layout_marginBottom="16dp"
         android:enabled="true"
         android:gravity="start|top"
-        android:textColor="?android:attr/textColorPrimary"
         android:hint="@string/edit_list_hint"
         android:inputType="textMultiLine"
         android:minLines="2"
@@ -30,6 +29,6 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        android:autofillHints="intervals" />
+        android:importantForAutofill="no" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/dialog_edit_recipes.xml
+++ b/app/src/main/res/layout/dialog_edit_recipes.xml
@@ -5,9 +5,6 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
 
-    <!-- TODO: Make maxLines vary with window (or screen) height,
-       e.g. 7 lines on WQVGA 240x432. Better yet, somehow adapt to
-       the space available above the soft keyboard. -->
     <EditText
         android:id="@+id/recipes_text_field"
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/dialog_edit_recipes.xml
+++ b/app/src/main/res/layout/dialog_edit_recipes.xml
@@ -18,7 +18,6 @@
         android:hint="@string/edit_list_hint"
         android:inputType="textMultiLine|textNoSuggestions"
         android:minLines="2"
-        android:maxLines="14"
         android:maxLength="2000"
         android:scrollbarAlwaysDrawHorizontalTrack="true"
         android:scrollbars="horizontal|vertical"

--- a/app/src/main/res/layout/dialog_edit_recipes.xml
+++ b/app/src/main/res/layout/dialog_edit_recipes.xml
@@ -16,7 +16,7 @@
         android:enabled="true"
         android:gravity="start|top"
         android:hint="@string/edit_list_hint"
-        android:inputType="textMultiLine"
+        android:inputType="textMultiLine|textNoSuggestions"
         android:minLines="2"
         android:maxLines="14"
         android:maxLength="2000"

--- a/app/src/main/res/layout/dialog_edit_recipes.xml
+++ b/app/src/main/res/layout/dialog_edit_recipes.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <!-- TODO: Make maxLines vary with window (or screen) height,
+       e.g. 7 lines on WQVGA 240x432. Better yet, somehow adapt to
+       the space available above the soft keyboard. -->
+    <EditText
+        android:id="@+id/recipes_text_field"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="4dp"
+        android:layout_marginTop="16dp"
+        android:layout_marginEnd="4dp"
+        android:layout_marginBottom="16dp"
+        android:enabled="true"
+        android:gravity="start|top"
+        android:textColor="?android:attr/textColorPrimary"
+        android:hint="@string/edit_list_hint"
+        android:inputType="textMultiLine"
+        android:minLines="2"
+        android:maxLines="14"
+        android:maxLength="2000"
+        android:scrollbarAlwaysDrawHorizontalTrack="true"
+        android:scrollbars="horizontal|vertical"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        android:autofillHints="intervals" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/menu/recipe_menu.xml
+++ b/app/src/main/res/menu/recipe_menu.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+    <group android:id="@+id/fixed_menu_group">
+        <item android:id="@+id/edit_recipes"
+            android:title="@string/edit_this_list" />
+    </group>
+    <group android:id="@+id/variable_menu_group" />
+</menu>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -7,7 +7,7 @@
     <string name="app_description">Eine Stoppuhr, die Sie auf dem Sperrbildschirm verwenden können.</string>
     <string name="cancel_edits">Abbrechen</string>
     <string name="dismiss_tip">Wischen um zu stoppen</string>
-    <string name="edit_list_hint">Alarmintervalle in Minuten, Minuten:Sekunden oder Stunden:Minuten:Sekunden, plus optionales Leerzeichen und Anmerkungen</string>
+    <string name="edit_list_hint">Minuten\nMinuten:Sekunden oder\nStunden:Minuten:Sekunden\nmit optionalen Anmerkungen</string>
     <string name="edit_list_title">Alarmintervalle</string>
     <string name="edit_this_list">Bearbeiten Sie diese Intervalle…</string>
     <string name="interval_hint">M, M:S, H:M:S</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -24,7 +24,7 @@
     <string name="pause_at_0_long">Anhalten bei 00:00</string>
     <string name="pause_at_0_short">Anhalten 0:00</string>
     <string name="reminder_switch">Periodisches Alarmintervall:</string>
-    <string name="recipes">7 Fisch, bis 63°C\n7 Burgers, bis 74°C\n:30\n1\n1:30\n2\n3\n4\n5\n6\n7\n8\n9\n10\n1:30:00</string>
+    <string name="recipes">6 Fisch, bis 63°C\n7 Burgers, bis 74°C\n:30\n1\n1:30\n2\n3\n4\n5\n6\n7\n8\n9\n10\n1:30:00</string>
     <string name="reset">Zurücksetzen</string>
     <string name="save_edits">Speichern</string>
     <string name="start">Start</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -24,7 +24,7 @@
     <string name="pause_at_0_long">Anhalten bei 00:00</string>
     <string name="pause_at_0_short">Anhalten 0:00</string>
     <string name="reminder_switch">Periodisches Alarmintervall:</string>
-    <string name="recipes">6 Fisch, bis %1$s\n7 Burgers, bis %2$s\n:30\n1\n1:30\n2\n3\n4\n5\n6\n7\n8\n9\n10\n1:30:00</string>
+    <string name="recipes">6 dünne Fisch, bis %1$s\n7 Burgers, bis %2$s\n:30\n1\n1:30\n2\n3\n4\n5\n6\n7\n8\n9\n10\n1:30:00</string>
     <string name="reset">Zurücksetzen</string>
     <string name="save_edits">Speichern</string>
     <string name="start">Start</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -24,7 +24,7 @@
     <string name="pause_at_0_long">Anhalten bei 00:00</string>
     <string name="pause_at_0_short">Anhalten 0:00</string>
     <string name="reminder_switch">Periodisches Alarmintervall:</string>
-    <string name="recipes">6 Fisch, bis 63°C\n7 Burgers, bis 74°C\n:30\n1\n1:30\n2\n3\n4\n5\n6\n7\n8\n9\n10\n1:30:00</string>
+    <string name="recipes">6 Fisch, bis %1$s\n7 Burgers, bis %2$s\n:30\n1\n1:30\n2\n3\n4\n5\n6\n7\n8\n9\n10\n1:30:00</string>
     <string name="reset">Zurücksetzen</string>
     <string name="save_edits">Speichern</string>
     <string name="start">Start</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -5,7 +5,11 @@
     <string name="alarm_unmute">STUMMSCHALTUNG AUFHEBEN</string>
     <string name="app_name">BBQ Timer</string>
     <string name="app_description">Eine Stoppuhr, die Sie auf dem Sperrbildschirm verwenden können.</string>
+    <string name="cancel_edits">Abbrechen</string>
     <string name="dismiss_tip">Wischen um zu stoppen</string>
+    <string name="edit_list_hint">Alarmintervalle in Minuten, Minuten:Sekunden oder Stunden:Minuten:Sekunden, plus optionales Leerzeichen und Anmerkungen</string>
+    <string name="edit_list_title">Alarmintervalle</string>
+    <string name="edit_this_list">Bearbeiten Sie diese Intervalle…</string>
     <string name="interval_hint">M, M:S, H:M:S</string>
     <string name="need_alarm_access">BBQ Timer benötigt „Spezieller App-Zugriff“ „Wecker und Erinnerungen“, um Alarme einzustellen</string>
     <string name="notification_alarm_channel_name">Alarm</string>
@@ -20,7 +24,9 @@
     <string name="pause_at_0_long">Anhalten bei 00:00</string>
     <string name="pause_at_0_short">Anhalten 0:00</string>
     <string name="reminder_switch">Periodisches Alarmintervall:</string>
+    <string name="recipes">7 Fisch, bis 63°C\n7 Burgers, bis 74°C\n:30\n1\n1:30\n2\n3\n4\n5\n6\n7\n8\n9\n10\n1:30:00</string>
     <string name="reset">Zurücksetzen</string>
+    <string name="save_edits">Speichern</string>
     <string name="start">Start</string>
     <string name="start_at_0_long">Start</string>
     <string name="start_at_0_short">Start</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -11,6 +11,7 @@
     <string name="edit_list_title">Alarmintervalle</string>
     <string name="edit_this_list">Bearbeiten Sie diese Intervalle…</string>
     <string name="interval_hint">M, M:S, H:M:S</string>
+    <string name="intervals_menu">Intervallmenü</string>
     <string name="need_alarm_access">BBQ Timer benötigt „Spezieller App-Zugriff“ „Wecker und Erinnerungen“, um Alarme einzustellen</string>
     <string name="notification_alarm_channel_name">Alarm</string>
     <string name="notification_alarm_channel_description">Wichtigkeit muss für Alarme hoch oder höher sein; Mittel oder höher für den Sperrbildschirm</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -9,7 +9,7 @@
     <string name="dismiss_tip">Wischen um zu stoppen</string>
     <string name="edit_list_hint">Minuten\nMinuten:Sekunden oder\nStunden:Minuten:Sekunden\nmit optionalen Anmerkungen</string>
     <string name="edit_list_title">Alarmintervalle</string>
-    <string name="edit_this_list">Bearbeiten Sie diese Intervalle…</string>
+    <string name="edit_this_list">Diese Intervalle bearbeiten…</string>
     <string name="interval_hint">M, M:S, H:M:S</string>
     <string name="intervals_menu">Intervallmenü</string>
     <string name="need_alarm_access">BBQ Timer benötigt „Spezieller App-Zugriff“ „Wecker und Erinnerungen“, um Alarme einzustellen</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -145,4 +145,22 @@
       Space is tight in a toast; this might not fit. -->
     <string name="need_alarm_access">BBQ Timer needs “Special app access” “Alarms &amp; reminders” to set alarms</string>
 
+    <!-- The initial "recipes" of alarm intervals with optional notes -->
+    <string name="recipes">7 fish, cook to 145°F\n7 burgers, cook to 165°F\n:30\n1\n1:30\n2\n3\n4\n5\n6\n7\n8\n9\n10\n1:30:00</string>
+
+    <!-- Menu command to edit the pop-up list of "recipes" of alarm intervals with optional notes. -->
+    <string name="edit_this_list">Edit these intervals…</string>
+
+    <!-- Title for the the dialog to edit "recipes" of alarm intervals with optional notes. -->
+    <string name="edit_list_title">Alarm intervals</string>
+
+    <!-- Hint for what to type into the recipe editor. -->
+    <string name="edit_list_hint">alarm intervals in minutes, minutes:seconds, or hours:minutes:seconds, plus optional space and notes</string>
+
+    <!-- Save edits in the recipe editor. -->
+    <string name="save_edits">Save</string>
+
+    <!-- Cancel edits in the recipe editor. -->
+    <string name="cancel_edits">Cancel</string>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -150,6 +150,9 @@
          The placeholder %2$s is for burgers temperature-done in either °C or °F. -->
     <string name="recipes">6 thin fish, cook to %1$s\n7 burgers, cook to %2$s\n:30\n1\n1:30\n2\n3\n4\n5\n6\n7\n8\n9\n10\n1:30:00</string>
 
+    <!-- Content description for the icon button that opens the menu of alarm intervals. -->
+    <string name="intervals_menu">Intervals menu</string>
+
     <!-- Menu command to edit the pop-up list of "recipes" of alarm intervals with optional notes. -->
     <string name="edit_this_list">Edit these intervals…</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -145,8 +145,10 @@
       Space is tight in a toast; this might not fit. -->
     <string name="need_alarm_access">BBQ Timer needs “Special app access” “Alarms &amp; reminders” to set alarms</string>
 
-    <!-- The initial "recipes" of alarm intervals with optional notes -->
-    <string name="recipes">6 fish, cook to 145°F\n7 burgers, cook to 165°F\n:30\n1\n1:30\n2\n3\n4\n5\n6\n7\n8\n9\n10\n1:30:00</string>
+    <!-- The initial "recipes" of alarm intervals with optional notes.
+         The placeholder %1$s is for fish temperature-done in either °C or °F.
+         The placeholder %2$s is for burgers temperature-done in either °C or °F. -->
+    <string name="recipes">6 thin fish, cook to %1$s\n7 burgers, cook to %2$s\n:30\n1\n1:30\n2\n3\n4\n5\n6\n7\n8\n9\n10\n1:30:00</string>
 
     <!-- Menu command to edit the pop-up list of "recipes" of alarm intervals with optional notes. -->
     <string name="edit_this_list">Edit these intervals…</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -146,7 +146,7 @@
     <string name="need_alarm_access">BBQ Timer needs “Special app access” “Alarms &amp; reminders” to set alarms</string>
 
     <!-- The initial "recipes" of alarm intervals with optional notes -->
-    <string name="recipes">7 fish, cook to 145°F\n7 burgers, cook to 165°F\n:30\n1\n1:30\n2\n3\n4\n5\n6\n7\n8\n9\n10\n1:30:00</string>
+    <string name="recipes">6 fish, cook to 145°F\n7 burgers, cook to 165°F\n:30\n1\n1:30\n2\n3\n4\n5\n6\n7\n8\n9\n10\n1:30:00</string>
 
     <!-- Menu command to edit the pop-up list of "recipes" of alarm intervals with optional notes. -->
     <string name="edit_this_list">Edit these intervals…</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -155,7 +155,7 @@
     <string name="edit_list_title">Alarm intervals</string>
 
     <!-- Hint for what to type into the recipe editor. -->
-    <string name="edit_list_hint">alarm intervals in minutes, minutes:seconds, or hours:minutes:seconds, plus optional space and notes</string>
+    <string name="edit_list_hint">minutes\nminutes:seconds or\nhours:minutes:seconds\nwith optional notes</string>
 
     <!-- Save edits in the recipe editor. -->
     <string name="save_edits">Save</string>

--- a/app/src/test/java/com/onefishtwo/bbqtimer/LocaleUtilsTest.java
+++ b/app/src/test/java/com/onefishtwo/bbqtimer/LocaleUtilsTest.java
@@ -1,0 +1,103 @@
+package com.onefishtwo.bbqtimer;
+
+import android.os.Build;
+
+import junit.framework.TestCase;
+
+import org.junit.Test;
+
+import java.util.Locale;
+
+import static com.onefishtwo.bbqtimer.LocaleUtils.formatTemperatureFromFahrenheit;
+import static com.onefishtwo.bbqtimer.LocaleUtils.getFormatDefault;
+import static com.onefishtwo.bbqtimer.LocaleUtils.useFahrenheit;
+
+public class LocaleUtilsTest extends TestCase {
+    private static final Locale BAHAMAS = new Locale("en", "BS");
+    private static final Locale SPAIN = new Locale("es", "ES");
+
+    private Locale initialLocale, initialFormatLocale;
+
+    @Override
+    protected void setUp() {
+        initialLocale = Locale.getDefault();
+
+        if (Build.VERSION.SDK_INT >= 24) {
+            initialFormatLocale = Locale.getDefault(Locale.Category.FORMAT);
+        }
+    }
+
+    @Override
+    protected void tearDown() {
+        Locale.setDefault(initialLocale);
+
+        if (Build.VERSION.SDK_INT >= 24) {
+            Locale.setDefault(Locale.Category.FORMAT, initialFormatLocale);
+        }
+    }
+
+    @Test
+    public void testGetFormatDefault() {
+        assertEquals(Locale.US, getFormatDefault());
+
+        Locale.setDefault(Locale.GERMANY);
+        assertEquals(Locale.GERMANY, getFormatDefault());
+
+        if (Build.VERSION.SDK_INT >= 24) {
+            Locale.setDefault(Locale.UK);
+
+            Locale.setDefault(Locale.Category.FORMAT, Locale.GERMANY);
+            assertEquals(Locale.GERMANY, getFormatDefault());
+
+            Locale.setDefault(Locale.Category.FORMAT, Locale.US);
+            assertEquals(Locale.US, getFormatDefault());
+        }
+    }
+
+    @Test
+    public void testUseFahrenheit() {
+        assertTrue(useFahrenheit(Locale.US));
+        assertTrue(useFahrenheit(BAHAMAS));
+
+        assertFalse(useFahrenheit(Locale.GERMANY));
+        assertFalse(useFahrenheit(SPAIN));
+
+        assertTrue(useFahrenheit());
+
+        Locale.setDefault(Locale.UK);
+        assertFalse(useFahrenheit());
+
+        if (Build.VERSION.SDK_INT >= 24) {
+            Locale.setDefault(BAHAMAS);
+            Locale.setDefault(Locale.Category.FORMAT, Locale.UK);
+            assertFalse(useFahrenheit());
+        }
+    }
+
+    @Test
+    public void testFormatTemperatureFromFahrenheit() {
+        assertEquals("32°F", formatTemperatureFromFahrenheit(32.0));
+        assertEquals("212°F", formatTemperatureFromFahrenheit(212.0));
+        assertEquals("145°F", formatTemperatureFromFahrenheit(145.0));
+        assertEquals("165°F", formatTemperatureFromFahrenheit(165.0));
+
+        // Test rounding
+        assertEquals("100°F", formatTemperatureFromFahrenheit(100.499));
+        assertEquals("101°F", formatTemperatureFromFahrenheit(100.5));
+
+        Locale.setDefault(Locale.GERMANY);
+        if (Build.VERSION.SDK_INT >= 24) {
+            Locale.setDefault(Locale.Category.FORMAT, Locale.GERMANY);
+        }
+
+        assertEquals("0°C", formatTemperatureFromFahrenheit(32.0));
+        assertEquals("100°C", formatTemperatureFromFahrenheit(212.0));
+        assertEquals("63°C", formatTemperatureFromFahrenheit(145.0));
+        assertEquals("74°C", formatTemperatureFromFahrenheit(165.0));
+
+        // Test rounding
+        assertEquals("100°C", formatTemperatureFromFahrenheit(212.8)); // 100.444°C
+        assertEquals("101°C", formatTemperatureFromFahrenheit(212.9)); // 100.5°C
+    }
+
+}

--- a/app/src/test/java/com/onefishtwo/bbqtimer/LocaleUtilsTest.java
+++ b/app/src/test/java/com/onefishtwo/bbqtimer/LocaleUtilsTest.java
@@ -2,8 +2,8 @@ package com.onefishtwo.bbqtimer;
 
 import android.os.Build;
 
-import junit.framework.TestCase;
-
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Locale;
@@ -11,15 +11,18 @@ import java.util.Locale;
 import static com.onefishtwo.bbqtimer.LocaleUtils.formatTemperatureFromFahrenheit;
 import static com.onefishtwo.bbqtimer.LocaleUtils.getFormatDefault;
 import static com.onefishtwo.bbqtimer.LocaleUtils.useFahrenheit;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
-public class LocaleUtilsTest extends TestCase {
+public class LocaleUtilsTest {
     private static final Locale BAHAMAS = new Locale("en", "BS");
     private static final Locale SPAIN = new Locale("es", "ES");
 
     private Locale initialLocale, initialFormatLocale;
 
-    @Override
-    protected void setUp() {
+    @Before
+    public void setUp() {
         initialLocale = Locale.getDefault();
 
         if (Build.VERSION.SDK_INT >= 24) {
@@ -27,8 +30,8 @@ public class LocaleUtilsTest extends TestCase {
         }
     }
 
-    @Override
-    protected void tearDown() {
+    @After
+    public void tearDown() {
         Locale.setDefault(initialLocale);
 
         if (Build.VERSION.SDK_INT >= 24) {

--- a/app/src/test/java/com/onefishtwo/bbqtimer/TimeCounterTest.java
+++ b/app/src/test/java/com/onefishtwo/bbqtimer/TimeCounterTest.java
@@ -32,11 +32,11 @@ import androidx.annotation.Nullable;
 import static android.text.format.DateUtils.HOUR_IN_MILLIS;
 import static android.text.format.DateUtils.MINUTE_IN_MILLIS;
 import static android.text.format.DateUtils.SECOND_IN_MILLIS;
+import static com.onefishtwo.bbqtimer.TimeCounter.lengthOfLeadingIntervalTime;
+import static com.onefishtwo.bbqtimer.TimeCounter.parseHhMmSs;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
-
-import static com.onefishtwo.bbqtimer.TimeCounter.parseHhMmSs;
 
 public class TimeCounterTest {
     static class MockSpanned implements Spanned {
@@ -200,5 +200,18 @@ public class TimeCounterTest {
         assertEquals("2:34:56", fc(2, 34, 56));
         assertEquals("5:04:00", fc(5, 4, 0));
         assertEquals("15:00:00", fc(15, 0, 0));
+    }
+
+    @Test
+    public void testLengthOfLeadingIntervalTime() {
+        assertEquals(1, lengthOfLeadingIntervalTime("7"));
+        assertEquals(4, lengthOfLeadingIntervalTime("  27"));
+        assertEquals(3, lengthOfLeadingIntervalTime("127, notes go here"));
+        assertEquals(5, lengthOfLeadingIntervalTime(" 3:15 "));
+        assertEquals(8, lengthOfLeadingIntervalTime("\t 1:3:15 "));
+        assertEquals(13, lengthOfLeadingIntervalTime(" 001:22:33:44 - notes"));
+        assertEquals(0, lengthOfLeadingIntervalTime("x15"));
+        assertEquals(3, lengthOfLeadingIntervalTime("\r\n7\r\n"));
+        assertEquals(1, lengthOfLeadingIntervalTime("7.5"));
     }
 }

--- a/bin/stuck-emulator.sh
+++ b/bin/stuck-emulator.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+# Send KEYCODE_MENU to the emulator to (hopefully) get it to respond to the
+# physical keyboard and mouse again.
+
+adb -e shell input keyevent 82

--- a/fastlane/metadata/android/de/full_description.txt
+++ b/fastlane/metadata/android/de/full_description.txt
@@ -1,6 +1,9 @@
 * <b>Kombinierter Intervalltimer/Stoppuhr</b> = periodische Alarme + verstrichene Zeit.
-    * Erinnert Sie regelmäßig daran, die Speisen zu wenden, während die Gesamtgarzeit verfolgt wird.
-* Schnellzugriff über <b>Sperrbildschirmbenachrichtigung</b> und <b>Startbildschirm-Widget</b>.
+    * Erinnert Sie regelmäßig daran, die Speisen zu wenden und verfolgt die gesamte Garzeit.
+* Schneller Zugriff über <b>Sperrbildschirmbenachrichtigung</b>,
+  <b>Pulldown-Benachrichtigung</b> und <b>Startbildschirm-Widget</b>.
+* Bearbeitbares <b>Popup-Menü der Intervallzeiten</b>. Greifen Sie schnell auf
+  Ihre bevorzugten Timer zu, jeweils mit optionalen Notizen.
 * <b>Änderbare Alarme</b> während es läuft.
 * Keine Werbung.
 
@@ -31,6 +34,8 @@ Geben Sie die Intervallzeit ein: <i>Minuten</i>, <i>Minuten:Sekunden</i> oder <i
 * Während der BBQ-Timer <i>läuft</i> oder <i>pausiert</i> ist, erscheint er <b>auf dem Sperrbildschirm</b> und <b>in der Pulldown-Benachrichtigung</b> Sie können es an diesen Stellen sehen und steuern.
     * Um es auf den Sperrbildschirm zu setzen, versetzen Sie es in den Modus <b>Pause</b> oder <b>Wiedergabe</b>, indem Sie auf Schaltflächen in der App oder im Startbildschirm-Widget tippen.
     * Sie können lange auf das Startbildschirmsymbol der App drücken und dann auf die Verknüpfung „Anhalten bei 00:00“ (auf Android 7.1+) tippen, um sie auf dem Sperrbildschirm anzuhalten und bereit zu machen.
+* Tippen Sie im Textfeld „Alarmintervall“ auf ▲, um das Popup-Menü für die Intervallzeit aufzurufen.
+    * Tippen Sie im Menü auf „Diese Intervalle bearbeiten…“, um das Menü anzupassen.
 * Die App, das Startbildschirm-Widget und die Pulldown-Benachrichtigung zeigen die Countdown-Intervallzeit sowie die verstrichene Gesamtzeit (erfordert Android 7+).
 * Sie können den „Alarm“-Ton von BBQ Timer in Einstellungen – Benachrichtigungen ändern. Wählen Sie nicht „Keine“, wenn Sie die Intervallalarme hören möchten. Um den Kuhglockenklang der App wiederherzustellen, deinstallieren Sie die App und installieren Sie sie erneut.
 

--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -1,6 +1,9 @@
 * <b>Combined interval timer/stopwatch</b> = periodic alarms + elapsed time.
-    * Reminds you periodically to turn the food while it tracks the total cooking time.
-* Quick access via <b>lock screen notification</b> and <b>home screen widget</b>.
+    * Reminds you periodically to turn the food and tracks the total cooking time.
+* Quick access via <b>lock screen notification</b>, <b>pull-down notification</b>,
+  and <b>home screen widget</b>.
+* Editable <b>pop-up menu of interval times</b>. Quickly access your favorite
+  timers, each with optional notes.
 * <b>Changeable alarms</b> while it’s running.
 * No ads.
 
@@ -31,6 +34,8 @@ Type in the interval time: <i>minutes</i>, <i>minutes:seconds</i>, or <i>hours:m
 * While BBQ Timer is <i>running</i> or <i>paused</i>, it appears <b>on the lock screen</b> and <b>in the pull-down notification</b> so you can see and control it in those places.
     * To put it on the lock screen, put it in <b>Pause</b> or <b>Play</b> mode by tapping buttons in the app or the home screen widget.
     * You can long-press the app’s home screen icon, then tap the “Pause at 00:00” shortcut (on Android 7.1+) to make it Paused and ready on the lock screen.
+* Tap ▲ in the alarm interval text field for the pop-up menu of interval times.
+    * Tap “Edit these intervals…” in the menu to customize the menu.
 * The app, home screen widget, and pull-down notification show the countdown interval time as well as the total elapsed time (requires Android 7+).
 * You can change BBQ Timer’s “Alarm” sound in Settings - Notifications. Don’t pick “None” if you want to hear the interval alarms. To restore the app’s cowbell sound, uninstall and reinstall the app.
 


### PR DESCRIPTION
* In the interval time EditText, format the value in a more compact form (`4` rather than `04:00`, `0:30` rather than `00:30`) so people don't extrapolate from the display to think they need to type in the long form.
* Add a pop-up menu of "recipes" -- interval times with optional notes.
* Add a recipe editor dialog.
* Use °F or °C in the default recipes, per the locale's country.
* Switch from Java 8 to 9 for `Set.of()`.
* Add unit tests and UI tests.
* Update library versions.
* Fix some inspection warnings.
* Workaround yet more Android bugs: Espresso flakiness, adjustPan failures, `defocusTextField()` vs. TAB and arrow key navigation, text field grabbing initial focus.